### PR TITLE
Interview project as public docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+*.cache
+*.log
+.git/
+.github/
+.dockerignore
+.editorconfig
+.env
+.env.*
+.gitignore
+.phpunit.result.cache
+docker-compose.*
+Dockerfile
+Makefile
+phpunit*
+README.md
+tests/
+vendor

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,23 +12,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    outputs:
-      docker: ${{ steps.filter.outputs.docker }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2.10.2
-      id: filter
-      with:
-        filters: |
-          docker:
-            - 'docker/**'
-
   build:
     runs-on: ubuntu-latest
-    needs: [init]
-    if: needs.init.outputs.docker == 'true'
     steps:
     - uses: actions/checkout@v3
     - name: Log in to the Container registry

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     outputs:
-      application: ${{ steps.filter.outputs.docker }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
     - uses: actions/checkout@v3
     - uses: dorny/paths-filter@v2.10.2
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [init]
-#    if: needs.init.outputs.docker == 'true'
+    if: needs.init.outputs.docker == 'true'
     steps:
     - name: Publish new image
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest
+        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,13 +40,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
-        file: ./docker/php/base/Dockerfile
+        file: ./docker/php/Dockerfile
         context: .
         push: true
-        tags: ghcr.io/pararius/php-fpm-grpc:latest
-#    - name: Build image
-#      run: |
-#        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
-#    - name: Publish image
-#      run: |
-#        docker push ghcr.io/pararius/php-fpm-grpc:latest
+        tags: ghcr.io/pararius/casco-job-interview:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,36 @@
+---
+name: Docker images
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      application: ${{ steps.filter.outputs.docker }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2.10.2
+      id: filter
+      with:
+        filters: |
+          docker:
+            - 'docker/**'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [init]
+    if: needs.init.outputs.docker == 'true'
+    steps:
+    - name: Publish new image
+      run: |
+        docker build -f docker/php/base/Dockerfile --tag ghcr.io/Pararius/php-fpm-grpc:latest
+        docker push ghcr.io/Pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [init]
-    if: needs.init.outputs.docker == 'true'
+#    if: needs.init.outputs.docker == 'true'
     steps:
     - name: Publish new image
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,7 +30,9 @@ jobs:
     needs: [init]
     if: needs.init.outputs.docker == 'true'
     steps:
-    - name: Publish new image
+    - name: Build image
       run: |
         docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+    - name: Publish image
+      run: |
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build ../../docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,9 +27,10 @@ jobs:
     needs: [init]
     if: needs.init.outputs.docker == 'true'
     steps:
+    - uses: actions/checkout@v3
     - name: Build image
       run: |
-        docker build . -f ./docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
     - name: Publish image
       run: |
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest
+        docker build docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build ../../docker/php/base -f ../../docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build ../../docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,13 +32,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Log in to the Container registry
-      uses: docker/login-action@V2
+      uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push Docker image
-      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      uses: docker/build-push-action@v3
       with:
         file: ./docker/php/base/Dockerfile
         context: .

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build docker/php/base -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build ../../docker/php/base -f ../../docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,5 +32,5 @@ jobs:
     steps:
     - name: Publish new image
       run: |
-        docker build -f docker/php/base/Dockerfile --tag ghcr.io/Pararius/php-fpm-grpc:latest
-        docker push ghcr.io/Pararius/php-fpm-grpc:latest
+        docker build -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest
+        docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,9 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -32,7 +29,7 @@ jobs:
     steps:
     - name: Build image
       run: |
-        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+        docker build . -f ./docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
     - name: Publish image
       run: |
         docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,9 @@ name: Docker images
 
 on:
   pull_request:
+    types: [closed]
+    branches:
+    - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   init:
@@ -28,9 +31,22 @@ jobs:
     if: needs.init.outputs.docker == 'true'
     steps:
     - uses: actions/checkout@v3
-    - name: Build image
-      run: |
-        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
-    - name: Publish image
-      run: |
-        docker push ghcr.io/pararius/php-fpm-grpc:latest
+    - name: Log in to the Container registry
+      uses: docker/login-action@V2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        file: ./docker/php/base/Dockerfile
+        context: .
+        push: true
+        tags: ghcr.io/pararius/php-fpm-grpc:latest
+#    - name: Build image
+#      run: |
+#        docker build . -f docker/php/base/Dockerfile --tag ghcr.io/pararius/php-fpm-grpc:latest --target php
+#    - name: Publish image
+#      run: |
+#        docker push ghcr.io/pararius/php-fpm-grpc:latest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code is already implemented, only not in a very object oriented way.
 
 ## Installation
 
-First make sure to install Docker and Docker Compose.
+First make sure to install [Docker](https://docs.docker.com/get-docker/).
 Then, to install everything:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Repo that is used by the Casco Team to do job interviews.
+Repo that is used by the Aanbod Team to do job interviews.
 
 In this assignment we are going to:
 - Read a CSV file
@@ -10,7 +10,8 @@ The code is already implemented, only not in a very object oriented way.
 
 ## Installation
 
-To install everything (assuming that you have docker and docker-compose):
+First make sure to install Docker and Docker Compose.
+Then, to install everything:
 
 ```sh
 make install
@@ -25,7 +26,7 @@ The application consists of 3 commands. You can run them inside the php containe
 
 ```sh
 make up
-docker-compose run --rm php sh
+docker compose run --rm php sh
 ```
 
 (This will automatically start the PubSub and Firestore emulator)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,7 @@ version: '3.7'
 
 services:
   php:
-    build:
-      context: docker/php
+    image: ghcr.io/pararius/casco-job-interview:latest
     volumes:
     - ./:/app:delegated
     - ~/.composer/cache:/composer/cache:delegated

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   php:
     build:
       context: docker/php
-      target: php
     volumes:
     - ./:/app:delegated
     - ~/.composer/cache:/composer/cache:delegated

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/Pararius/php-fpm-grpc:latest as php
+FROM ghcr.io/pararius/php-fpm-grpc:latest as php
 
 ENV COMPOSER_MEMORY_LIMIT -1
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,6 +2,7 @@ FROM mlocati/php-extension-installer:1.5 AS extension-installer
 FROM php:8.1.6-fpm-alpine3.15 AS php
 COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions \
+      grpc-1.44.0 \
       intl \
     ;
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,8 +1,15 @@
-FROM ghcr.io/pararius/php-fpm-grpc:latest as php
+FROM mlocati/php-extension-installer:1.5 AS extension-installer
+FROM php:8.1.6-fpm-alpine3.15 AS php
+COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
+RUN install-php-extensions \
+      intl \
+    ;
 
 ENV COMPOSER_MEMORY_LIMIT -1
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"
 
 WORKDIR /app

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/real-estate-classifieds/shared/php:8.1 as php
+FROM ghcr.io/Pararius/php-fpm-grpc:latest as php
 
 ENV COMPOSER_MEMORY_LIMIT -1
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -1,0 +1,8 @@
+LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"
+FROM mlocati/php-extension-installer:1.5 AS extension-installer
+FROM php:8.1.6-fpm-alpine3.15 AS php
+COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
+RUN install-php-extensions \
+      grpc-1.44.0 \
+      intl \
+    ;

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -2,7 +2,6 @@ FROM mlocati/php-extension-installer:1.5 AS extension-installer
 FROM php:8.1.6-fpm-alpine3.15 AS php
 COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions \
-      grpc-1.44.0 \
       intl \
     ;
 

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -5,4 +5,5 @@ RUN install-php-extensions \
       grpc-1.44.0 \
       intl \
     ;
+
 LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -4,5 +4,5 @@ COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions \
       grpc-1.44.0 \
       intl \
-    ; \
+    ;
 LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -1,8 +1,8 @@
-LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"
 FROM mlocati/php-extension-installer:1.5 AS extension-installer
 FROM php:8.1.6-fpm-alpine3.15 AS php
 COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions \
       grpc-1.44.0 \
       intl \
-    ;
+    ; \
+LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"

--- a/docker/php/base/Dockerfile
+++ b/docker/php/base/Dockerfile
@@ -1,8 +1,0 @@
-FROM mlocati/php-extension-installer:1.5 AS extension-installer
-FROM php:8.1.6-fpm-alpine3.15 AS php
-COPY --from=extension-installer /usr/bin/install-php-extensions /usr/bin/
-RUN install-php-extensions \
-      intl \
-    ;
-
-LABEL org.opencontainers.image.source="https://github.com/Pararius/casco-job-interview"


### PR DESCRIPTION
This pr switches from using our private php image to a public image so applicants can install the project themselves at home before starting the second interview round.
I chose to package everything for now instead of only the base php image. This project rarely gets any updates to the longer build time isn't really an issue.
I might still be a good idea to have a public php image with grpc pre-installed, but I suggest we build and push that from the `docker-images` repo.
